### PR TITLE
Migrating to Python 3.10

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     author_email="ehasanaj@cs.cmu.edu",
     description=("Gene enrichment made easy."),
     long_description=("Same as above."),
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )

--- a/src/grinch/conf.py
+++ b/src/grinch/conf.py
@@ -1,7 +1,7 @@
 import abc
 import inspect
 from itertools import islice
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Extra, Field
 
@@ -117,7 +117,7 @@ class BaseConfigurable(_BaseConfigurable):
         self,
         message: str,
         shape: Tuple[int, int] = None,
-        artifacts: Optional[Union[str, List[str]]] = None
+        artifacts: Optional[str | List[str]] = None
     ) -> None:
         """Sends a report to reporter for logging.
 

--- a/src/grinch/pipeline.py
+++ b/src/grinch/pipeline.py
@@ -1,0 +1,2 @@
+import logging
+

--- a/src/grinch/processors.py
+++ b/src/grinch/processors.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 class BaseProcessor(BaseConfigurable):
     """A base class for dimensionality reduction, clustering and other
-    processors.
+    processors. A processor cannot update the data matrix X, but can use it
+    to perform any kind of fitting.
     """
 
     class Config(BaseConfigurable.Config):

--- a/src/grinch/reporter.py
+++ b/src/grinch/reporter.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, Extra
 
@@ -8,7 +8,7 @@ class Report(BaseModel):
     config: Optional[BaseModel] = None
     message: Optional[str] = None
     shape: Optional[Tuple[int, int]] = None
-    artifacts: Optional[Union[str, List[str]]] = None
+    artifacts: Optional[str | List[str]] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/grinch/transformers.py
+++ b/src/grinch/transformers.py
@@ -1,6 +1,6 @@
 import abc
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from anndata import AnnData
 from pydantic import Field, validator
@@ -47,7 +47,7 @@ class PCA(BaseTransformer):
         read_key: str = "X"
         save_key: str = f"obsm.{OBSM.X_PCA}"
         # PCA args
-        n_components: Optional[Union[int, float, str]] = None
+        n_components: Optional[int | float | str] = None
         whiten: bool = False
         svd_solver: str = 'auto'
 


### PR DESCRIPTION
Summary: Following the recent numba update, we can now migrate to Python 3.10. Modified the `Union` syntax to use pipes `|` instead.