### PR TITLE
Moving _process and predict inside BasePredictor

### DIFF
--- a/src/grinch/predictors.py
+++ b/src/grinch/predictors.py
@@ -19,6 +19,7 @@ class BasePredictor(BaseProcessor, abc.ABC):
 
     class Config(BaseProcessor.Config):
         x_key: str = f"obsm.{OBSM.X_PCA}"
+        labels_key: str
         save_stats: bool = True
         kwargs: Dict[str, Any] = {}
 


### PR DESCRIPTION
Summary: Moving `_process` and `predict` methods inside the base class since most predictors implement the same interface. Leaving it up to the derived class to override these if labels y are required or if the API is different.