### PR TITLE
Adding base classes for unsupervised and supervised predictors

### DIFF
--- a/src/grinch/pipeline.py
+++ b/src/grinch/pipeline.py
@@ -62,5 +62,5 @@ class GRPipeline(BaseConfigurable):
                     raise TypeError("Splitters cannot be used with the validation set.")
                 case GroupProcess():
                     raise TypeError("GroupProcess cannot be used with the validation set.")
-                case _: # default to simple processing
+                case _:  # default to simple processing
                     processor(ds.VAL_SPLIT)


### PR DESCRIPTION
Summary: Add base classes for unsupervised predictors which use a single X representation, and supervised predictors which use X and y.