### PR TITLE
Add support for multiple dots in representation keys

### DIFF
--- a/src/grinch/aliases.py
+++ b/src/grinch/aliases.py
@@ -32,13 +32,13 @@ class AnnDataKeys:
 
     class VARM:
         LOG_REG_COEF = auto()
-        TTEST = auto()
 
     class UNS:
         X_PCA = auto()
         X_TRUNCATED_SVD = auto()
         KMEANS = auto()
         LOG_REG = auto()
+        TTEST = auto()
 
 
 # Create shorter aliases, since these will be used a lot

--- a/src/grinch/de.py
+++ b/src/grinch/de.py
@@ -9,7 +9,7 @@ from pydantic import validator
 from sklearn.utils import indexable
 from statsmodels.stats.multitest import multipletests
 
-from .aliases import VARM
+from .aliases import UNS
 from .processors import BaseProcessor
 from .utils.ops import group_indices
 from .utils.stats import ttest
@@ -61,15 +61,14 @@ class TestSummary:
         where rows are the tests performed.
         """
         to_stack = [self.pvals, self.qvals, self.log2fc, self.mean1, self.mean2]
-        return np.vstack(to_stack).T.astype(dtype) # type: ignore
+        return np.vstack(to_stack).T.astype(dtype)  # type: ignore
 
 
 class TTest(BaseProcessor):
 
     class Config(BaseProcessor.Config):
         x_key: str = "X"
-        summary_prefix_key: str = f"varm.{VARM.TTEST}"
-        splitter: str = ':'
+        summary_prefix_key: str = f"uns.{UNS.TTEST}"
         group_key: str
         is_logged: bool = False
         # If the data is logged, this should point to the base of the
@@ -130,5 +129,5 @@ class TTest(BaseProcessor):
                 log2fc=log2fc,
             )
 
-            key = f"{self.cfg.summary_prefix_key}{self.cfg.splitter}{label}"
+            key = f"{self.cfg.summary_prefix_key}.{label}"
             self.set_repr(adata, key, ts.to_array())

--- a/src/grinch/utils/ops.py
+++ b/src/grinch/utils/ops.py
@@ -1,9 +1,22 @@
+from functools import reduce
 from typing import List, Optional, Tuple
 
 import numpy as np
 from sklearn.utils import column_or_1d
 
 from ..custom_types import NP1D_bool, NP1D_int, NP_bool
+
+
+def IDENTITY(x):
+    """Identity function."""
+    return x
+
+
+def compose(*funcs):
+    """Composes functions left to right, i.e., the first function on the
+    list will be applied first."""
+    composed = reduce(lambda f, g: lambda x: g(f(x)), funcs, IDENTITY)
+    return composed
 
 
 def true_inside(x, v1: Optional[float], v2: Optional[float]) -> NP_bool:

--- a/tests/test_ttest.py
+++ b/tests/test_ttest.py
@@ -5,7 +5,7 @@ from anndata import AnnData
 from hydra.utils import instantiate
 from omegaconf import OmegaConf
 
-from grinch import VARM
+from grinch import UNS
 
 from ._utils import to_view
 
@@ -29,7 +29,6 @@ def test_ttest(X):
         {
             "_target_": "src.grinch.TTest.Config",
             "group_key": "obs.label",
-            "splitter": ":",
         }
     )
     cfg = instantiate(cfg)
@@ -38,8 +37,8 @@ def test_ttest(X):
     adata.obs['label'] = label
 
     ttest(adata)
-    pvals = adata.varm[f'{VARM.TTEST}:0'][:, 0]
-    log2fc = adata.varm[f'{VARM.TTEST}:0'][:, 2]
+    pvals = adata.uns[UNS.TTEST]['0'][:, 0]
+    log2fc = adata.uns[UNS.TTEST]['0'][:, 2]
 
     assert pvals[0] < 0.05
     assert pvals[1] < 0.05


### PR DESCRIPTION
Summary: Add support for multiple dots in representation keys.

- Only `uns` supports multiple dots.
- The first dot splits the object and the attribute, while all other consequent dots are treated as dictionary keys.
- If a key is not found, an empty dict is initialized (except for the last key).
- Switched ttest to use `uns` instead of varm.