### PR TITLE
Switching to a dataframe format for DE test summary

### DIFF
--- a/tests/test_ttest.py
+++ b/tests/test_ttest.py
@@ -37,8 +37,8 @@ def test_ttest(X):
     adata.obs['label'] = label
 
     ttest(adata)
-    pvals = adata.uns[UNS.TTEST]['0'][:, 0]
-    log2fc = adata.uns[UNS.TTEST]['0'][:, 2]
+    pvals = adata.uns[UNS.TTEST]['0']['pvals'].to_numpy()
+    log2fc = adata.uns[UNS.TTEST]['0']['log2fc'].to_numpy()
 
     assert pvals[0] < 0.05
     assert pvals[1] < 0.05


### PR DESCRIPTION
Summary: Storing DE test results as a DataFrame rather than a numpy array. This is more convenient and is supported by anndata during write.