### PR TITLE
Add type overload for as_mask

### DIFF
--- a/src/grinch/de_test_summary.py
+++ b/src/grinch/de_test_summary.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple
+from typing import Dict, Literal, Optional, Tuple, overload
 
 import numpy as np
 import pandas as pd
@@ -95,7 +95,13 @@ class DETestSummary(BaseModel):
         """Constructs an instance of TestSummary given a df."""
         return cls.from_dict(val.to_dict('list'))
 
-    def where(self, *conds: FilterCondition, as_mask: bool = False) -> NP1D_int | NP1D_bool:
+    @overload
+    def where(self, *conds: FilterCondition, as_mask: Literal[True]) -> NP1D_bool: ...
+
+    @overload
+    def where(self, *conds: FilterCondition, as_mask: Literal[False]) -> NP1D_int: ...
+
+    def where(self, *conds, as_mask=False) -> NP1D_int | NP1D_bool:
         """Given a condition which conists of a key field, a threshold
         (cutoff or top_k), return a mask or list of indices which satisfy
         the conditions.

--- a/src/grinch/processors/masking.py
+++ b/src/grinch/processors/masking.py
@@ -1,0 +1,22 @@
+from typing import Dict
+
+from anndata import AnnData
+
+from ..filter_condition import FilterCondition, StackedFilterCondition
+from ..custom_types import NP1D_bool
+from .base_processor import BaseProcessor
+
+
+class StoreAsMask(BaseProcessor):
+    # Simple class that stores a mask of filtered conditions
+
+    class Config(BaseProcessor.Config):
+        filter_by: Dict[str, FilterCondition]
+        save_key: str
+
+    cfg: Config
+
+    def _process(self, adata: AnnData) -> None:
+        sfc = StackedFilterCondition(*self.cfg.filter_by.values())
+        mask: NP1D_bool = sfc(adata, as_mask=True)
+        self.set_repr(adata, self.cfg.save_key, mask)


### PR DESCRIPTION
Summary: `mypy` complains about selecting a type from a union return type that depends on a flag. Overloading function calls using `overload` fixes this issue. Also, adding a `StoreAsMask` processor that takes filters and stores them as a mask.