### PR TITLE
Fix save prefix being incorrectly set based on group key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ tags
 grinch.egg*
 *cache
 data
-conf*
+conf/*
+!conf/example_DE_analysis.yaml

--- a/conf/dimensionality_reduction.yaml
+++ b/conf/dimensionality_reduction.yaml
@@ -1,1 +1,0 @@
-_target_: grinch.UMAP.Config

--- a/conf/example_DE_analysis.yaml
+++ b/conf/example_DE_analysis.yaml
@@ -1,0 +1,22 @@
+_target_: grinch.GRPipeline.Config
+
+data_readpath: 'data/stub.h5ad'
+data_writepath: 'data/stub_processed.h5ad'
+
+no_data_write: false
+
+processors:
+  - _target_: grinch.GroupProcess.Config
+    group_key: obs.y
+    processor:
+      _target_: grinch.TTest.Config
+      group_key: obs.category
+  - _target_: grinch.GroupProcess.Config
+    group_key: obs.category
+    processor:
+      _target_: grinch.GroupProcess.Config
+      group_key: obs.y
+      min_points_per_group: 25
+      drop_small_groups: true
+      processor:
+        _target_: grinch.BimodalTest.Config

--- a/conf/preprocessing.yaml
+++ b/conf/preprocessing.yaml
@@ -1,4 +1,0 @@
-_target_: grinch.FilterCells.Config
-
-min_counts: 3
-min_genes: 50

--- a/src/grinch/processors/de.py
+++ b/src/grinch/processors/de.py
@@ -106,7 +106,8 @@ class TTest(BaseProcessor):
         group_labels = column_or_1d(self.get_repr(adata, self.cfg.group_key))
         unq_labels = np.unique(group_labels)
         if len(unq_labels) <= 1:
-            raise ValueError(f"Found only one unique value under key '{self.cfg.group_key}'")
+            logger.warning(f"Found only one unique value under key '{self.cfg.group_key}'")
+            return
 
         x = self.get_repr(adata, self.cfg.x_key)
         x = check_array(
@@ -125,7 +126,7 @@ class TTest(BaseProcessor):
         )
         for label in to_iter:
             ts: DETestSummary = self._ttest(pmv, label)
-            key = f"{self.cfg.save_key}.{label}"
+            key = f"{self.cfg.save_key}.{self.cfg.group_key.rsplit('.')[-1]}-{label}"
             self.store_item(key, ts.df())
 
 

--- a/src/grinch/processors/group.py
+++ b/src/grinch/processors/group.py
@@ -55,29 +55,12 @@ class GroupProcess(BaseProcessor):
         def ensure_correct_axis(cls, axis):
             return validate_axis(axis)
 
-        @validator('group_prefix')
-        def has_label_and_uns(cls, val, values):
-            if "{label}" in val and not values['group_key'].startswith('uns'):
-                raise ValueError("Non-uns group_key's cannot be used with a label prefix.")
-            return val
-
-        def updates_uns(self) -> bool:
-            return self.group_key.startswith('uns.')
-
         def update_processor_save_key_prefix(self, label):
-            prefix = self.get_save_key_prefix(
+            self.processor.save_key_prefix = self.get_save_key_prefix(
                 self.group_prefix,
                 label=label,
                 group_key=self.group_key.rsplit('.', maxsplit=1)[-1],
             )
-            if not self.updates_uns() and '.' in prefix:
-                logger.warning(
-                    "Non 'uns' group_key was entered, but 'group_prefix' "
-                    "contains dots. Replacing 'group_prefix' dots with dashes."
-                )
-                prefix = prefix.replace('.', '-')
-
-            self.processor.save_key_prefix = prefix
 
     cfg: Config
 

--- a/src/grinch/processors/indexer.py
+++ b/src/grinch/processors/indexer.py
@@ -1,4 +1,5 @@
 import abc
+import gc
 from typing import Dict
 
 from anndata import AnnData
@@ -55,6 +56,8 @@ class InplaceIndexer(BaseIndexer):
             adata._inplace_subset_obs(mask)
         else:
             adata._inplace_subset_var(mask)
+
+        gc.collect()
 
 
 class IndexProcessor(BaseIndexer):

--- a/tests/test_ttest.py
+++ b/tests/test_ttest.py
@@ -37,9 +37,9 @@ def test_ttest(X):
     adata.obs['label'] = label
 
     ttest(adata)
-    pvals = adata.uns[UNS.TTEST]['0']['pvals'].to_numpy()
-    log2fc = adata.uns[UNS.TTEST]['0']['log2fc'].to_numpy()
-    dd = DETestSummary.from_df(adata.uns[UNS.TTEST]['0'])
+    pvals = adata.uns[UNS.TTEST]['label-0']['pvals'].to_numpy()
+    log2fc = adata.uns[UNS.TTEST]['label-0']['log2fc'].to_numpy()
+    dd = DETestSummary.from_df(adata.uns[UNS.TTEST]['label-0'])
     assert_allclose(dd.pvals, pvals)
     assert_allclose(dd.log2fc, log2fc)
 
@@ -55,9 +55,9 @@ def test_ttest(X):
     assert log2fc[3] > 2
     assert log2fc[4] > 2
 
-    pvals = adata.uns[UNS.TTEST]['1']['pvals'].to_numpy()
-    log2fc = adata.uns[UNS.TTEST]['1']['log2fc'].to_numpy()
-    dd = DETestSummary.from_df(adata.uns[UNS.TTEST]['1'])
+    pvals = adata.uns[UNS.TTEST]['label-1']['pvals'].to_numpy()
+    log2fc = adata.uns[UNS.TTEST]['label-1']['log2fc'].to_numpy()
+    dd = DETestSummary.from_df(adata.uns[UNS.TTEST]['label-1'])
     assert_allclose(dd.pvals, pvals)
     assert_allclose(dd.log2fc, log2fc)
 


### PR DESCRIPTION
Summary: Fixed a bug with `save_key_prefix` not using the correct anndata column. Adding example config for DE analysis.