### PR TITLE
Separate pval test summary, add check for no gene set hits

### DIFF
--- a/src/grinch/filter_condition.py
+++ b/src/grinch/filter_condition.py
@@ -62,6 +62,8 @@ class FilterCondition(BaseModel):
         idx = np.argsort(arr) if self.ordered else np.argpartition(arr, self.top_k)
         idx = idx[:self.top_k]
         if not as_mask:
+            if self.ordered:
+                logger.warning("'ordered=True' will be ignored when returning mask.")
             return idx
 
         mask = np.full_like(arr, False, dtype=bool)
@@ -77,6 +79,8 @@ class FilterCondition(BaseModel):
 
         mask = arr >= self.cutoff if self.greater_is_better else arr <= self.cutoff
         if as_mask:
+            if self.ordered:
+                logger.warning("'ordered=True' will be ignored when returning mask.")
             return mask
 
         idx = np.argwhere(mask).ravel()

--- a/src/grinch/processors/enrich.py
+++ b/src/grinch/processors/enrich.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Type
 
 import gseapy as gp
 import numpy as np
@@ -11,17 +11,25 @@ from sklearn.utils.validation import column_or_1d
 
 from ..aliases import UNS
 from ..custom_types import NP1D_int, NP1D_str
-from ..de_test_summary import DETestSummary, FilterCondition
+from ..de_test_summary import DETestSummary, FilterCondition, TestSummary
 from ..utils.validation import pop_args
 from .base_processor import BaseProcessor
 
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_FILTERS: Dict[str, FilterCondition] = {
-    'filter-by-qval': FilterCondition(key='qvals', cutoff=0.05, greater_is_better=False),
-    'filter-by-log2fc': FilterCondition(key='log2fc', cutoff=1, greater_is_better=True),
-}
+DEFAULT_FILTERS: List[FilterCondition] = [
+    FilterCondition(key='qvals', cutoff=0.05, greater_is_better=False),
+    FilterCondition(key='log2fc', cutoff=1, greater_is_better=True),
+]
+
+DEFAULT_GENE_SET = "HuBMAP_ASCTplusB_augmented_2022"
+
+EMPTY_TEST = pd.DataFrame(columns=[
+    'Gene_set', 'Term', 'Overlap', 'P-value', 'Adjusted P-value',
+    'Old P-value', 'Old Adjusted P-value', 'Odds Ratio', 'Combined Score',
+    'Genes'
+])
 
 
 class GSEA(BaseProcessor):
@@ -40,7 +48,7 @@ class GSEA(BaseProcessor):
         dict, or to a single dataframe otherwise.
     gene_sets: str or list of str
         Names of gene sets to use for GSEA.
-    filter_by: dict of FilterCondition
+    filter_by: list of FilterCondition
         These will be used to filter genes for GSEA. Dict keys are ignored.
     gene_names_key: str
         Key to use for parsing gene symbols (names). Can be 'var_names' or
@@ -53,11 +61,13 @@ class GSEA(BaseProcessor):
         read_key: str = f"uns.{UNS.TTEST}"
         save_key: str = f"uns.{UNS.GSEA}"
 
-        gene_sets: List[str] | str = "HuBMAP_ASCTplusB_augmented_2022"
+        gene_sets: List[str] | str = DEFAULT_GENE_SET
         # Dict of keys to use for filtering DE genes; keys are ignored
-        filter_by: Dict[str, FilterCondition] = DEFAULT_FILTERS
+        filter_by: List[FilterCondition] = DEFAULT_FILTERS
         gene_names_key: str = "var_names"
         kwargs: Dict[str, Any] = {}
+        # not to be used in a config
+        test_type: Type[TestSummary] = DETestSummary
 
         @validator('kwargs')
         def remove_explicit_args(cls, val):
@@ -74,64 +84,81 @@ class GSEA(BaseProcessor):
     @staticmethod
     def _gsea(
         gene_list: List[str] | NP1D_str,
-        gene_sets: List[str] | str = "HuBMAP_ASCTplusB_augmented_2022",
+        gene_sets: List[str] | str = DEFAULT_GENE_SET,
         **kwargs
     ) -> pd.DataFrame:
         """Wrapper around gp.enrichr."""
-        if hasattr(gene_list, 'tolist') and not isinstance(gene_list, list):  # 2nd if for mypy
+        if hasattr(gene_list, 'tolist') and not isinstance(gene_list, list):
             gene_list = gene_list.tolist()
-        return gp.enrichr(gene_list=gene_list, gene_sets=gene_sets, no_plot=True, **kwargs).results
+
+        logger.info(f"Using {len(gene_list)} genes.")
+        try:
+            results = gp.enrichr(
+                gene_list=gene_list,
+                gene_sets=gene_sets,
+                no_plot=True,
+                **kwargs,
+            ).results
+        except ValueError as ve:
+            # Occurs when no gene set has a hit
+            logger.warning(f"No hits found. {str(ve)}")
+            return EMPTY_TEST
+        return results
 
     @staticmethod
     def _process_de_test(
-        test: pd.DataFrame | DETestSummary,
+        test: pd.DataFrame | TestSummary,
         gene_list_all: NP1D_str,
-        filter_by: Dict[str, FilterCondition]
+        *,
+        filter_by: List[FilterCondition],
+        gene_sets: List[str] | str = DEFAULT_GENE_SET,
+        test_type: Type[TestSummary] = DETestSummary,
     ) -> pd.DataFrame:
-        """Process a single DataFrame or DETestSummary object.
+        """Process a single DataFrame or TestSummary object.
 
         Parameters
         __________
-        test: pd.DataFrame or DETestSummary
+        test: pd.DataFrame or TestSummary
             Must contain keys specified in all FilterCondition's passed.
         gene_list_all: ndarray of str
             List of all genes to select from. Must have the same length as
             test.
-        filter_by: dict of FilterCondition
+        filter_by: List of FilterCondition
             Determine which genes to pick from gene_list_all based on
             results of test.
+        test_type: type
+            Should point to the type of test to convert test to.
 
         Returns
         _______
         A pandas DataFrame with test results.
         """
         if isinstance(test, pd.DataFrame):
-            test = DETestSummary.from_df(test)
-        elif not isinstance(test, DETestSummary):
-            raise TypeError(f"Expected DataFrame or DETestSummary but found {type(test)}.")
+            test = test_type.from_df(test)
+        elif not isinstance(test, test_type):
+            raise TypeError(
+                f"Expected DataFrame or {test_type.__name__} but found {type(test)}."
+            )
 
         if len(gene_list_all) != len(test):
             raise ValueError(
-                "Expected gene_list to be of same length as DETestSummary, but "
-                f"found gene_list of length {len(gene_list_all)} and DETestSummary "
+                f"Expected gene_list to be of same length as {test_type.__name__}, but "
+                f"found gene_list of length {len(gene_list_all)} and {test_type.__name__} "
                 f"of length {len(test)}."
             )
 
         # Apply all filters
-        gene_idx: NP1D_int = test.where(*filter_by.values(), as_mask=False)
+        gene_idx: NP1D_int = test.where(*filter_by, as_mask=False)
         gene_list = gene_list_all[gene_idx]
         if len(gene_list) == 0:  # empty list
             logger.warning('Encountered empty gene list.')
             # Empty dataframe
-            return pd.DataFrame(columns=[
-                'Gene_set', 'Term', 'Overlap', 'P-value', 'Adjusted P-value',
-                'Old P-value', 'Old Adjusted P-value', 'Odds Ratio', 'Combined Score',
-                'Genes'])
-        return GSEA._gsea(gene_list)
+            return EMPTY_TEST
+        return GSEA._gsea(gene_list, gene_sets=gene_sets)
 
     def _process_dict(
         self,
-        test_dict: Dict[str, Dict | pd.DataFrame | DETestSummary],
+        test_dict: Dict[str, Dict | pd.DataFrame | TestSummary],
         prefix: str,
         func: Callable
     ) -> None:
@@ -140,6 +167,7 @@ class GSEA(BaseProcessor):
             if isinstance(v, dict):
                 self._process_dict(v, prefix=f'{k}.', func=func)
             else:
+                logger.info(f"Running GSEA for '{k}'.")
                 gsea_test_summary: pd.DataFrame = func(v)
                 save_key = f'{self.cfg.save_key}.{prefix}{k}'
                 self.store_item(save_key, gsea_test_summary)
@@ -158,7 +186,9 @@ class GSEA(BaseProcessor):
         _gsea_f = partial(
             GSEA._process_de_test,
             gene_list_all=gene_list_all,
-            filter_by=self.cfg.filter_by
+            gene_sets=self.cfg.gene_sets,
+            filter_by=self.cfg.filter_by,
+            test_type=self.cfg.test_type,
         )
         tests = self.get_repr(adata, self.cfg.read_key)
         if isinstance(tests, dict):  # Dict of tests

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -30,10 +30,10 @@ def test_enrich(X):
     cfg = OmegaConf.create(
         {
             "_target_": "src.grinch.GSEA.Config",
-            "filter_by": {'c1': fcfg},
+            "filter_by": [fcfg],
         }
     )
-    cfg = instantiate(cfg)
+    cfg = instantiate(cfg, _convert_='all')
     gsea = cfg.initialize()
     adata = AnnData(X)
     ts = DETestSummary(pvals=[0.02, 0.5, 1, 0.01, 0.8])


### PR DESCRIPTION
Summary: Separating `TestSummary` and `PvalTestSummary` classes. Adding a check to enrich for cases when none of the gene sets has a hit. Adding `__str__` and `__repr__` to `TestSummary`.